### PR TITLE
Fix code scanning alert no. 2: Useless regular-expression character escape

### DIFF
--- a/test/project.test.ts
+++ b/test/project.test.ts
@@ -98,7 +98,7 @@ describe("Check emulator functions", function () {
         expect(lastCall.contract).to.eq("DeBridgeGate");
         expect(lastCall.sourceName).to.match(
           new RegExp(
-            "https://github.com/debridge-finance/debridge-contracts-v1/blob/[a-z0-9\.]+/contracts/transfers/DeBridgeGate.sol"
+            "https://github.com/debridge-finance/debridge-contracts-v1/blob/[a-z0-9.]+/contracts/transfers/DeBridgeGate.sol"
           )
         );
       }


### PR DESCRIPTION
Fixes [https://github.com/Dargon789/hardhat-debridge/security/code-scanning/2](https://github.com/Dargon789/hardhat-debridge/security/code-scanning/2)

To fix the problem, we need to remove the unnecessary backslash in the regular expression string. Specifically, we should replace `\.` with `.` in the regular expression on line 101. This change will not alter the functionality of the code but will make the regular expression clearer and more correct.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

Bug Fixes:
- Fix code scanning alert by removing the unnecessary backslash in the regular expression string.